### PR TITLE
Printing proof + dev updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,75 @@
 
 Node.js >= 8.5.0
 
-## Building and Testing Contracts
+## Building
 
 ```
 git clone https://github.com/livepeer/merkle-mine.git
 cd merkle-mine
 npm install
+```
 
-npm run compile
+## Running Client Scripts
+
+In the following sections, it is assumed that the user has obtained a file with a list of accounts created from steps 1 and 2 in the MerkleMine token generation algorithm
+defined in the [specification](SPEC.md). This file might have been obtained from a hosted source such as IPFS or independently created by following steps 1 and 2 in the MerkleMine
+token generation algorithm in the specification.
+
+Flags
+- `--rinkeby`: boolean flag to indicate that the script should use the Rinkeby Ethereum test network
+- `--dev`: boolean flag to indicate that the script should use an Ethereum client running with JSON-RPC endpoints at http://localhost:8545
+- `--acctFile`: path to file with list of accounts to be used for Merkle tree construction
+- `--generate`: boolean flag to indicate whether the script should submit the MerkleMine contract transaction
+- `--datadir`: path to data directory containing local keystore files. Required if `--generate` flag is enabled
+- `--caller`: address of account used to submit the MerkleMine contract transaction. Required if `--generate` flag is enabled
+- `--merkleMine`: address of MerkleMine contract
+- `--recipient`: address of account that is included in the MerkleMine genesis state that is the recipient of a token allocation
+
+### Generating a token allocation
+
+Note: the `--max-old-space-size=4096` flag is to increase the Node.js memory limit from its default to ensure that the current Merkle tree construction implementation
+can complete (4096 is an arbitrarily set value).
+
+```
+# By default this command will use the Ethereum main network
+# Use the --rinkeby flag to use the Rinkeby Ethereum test network
+# Use the --dev flag to use a custom development network with an Ethereum client (ganache-cli, Geth, Parity) running with JSON-RPC endpoints at http://localhost:8545
+node --max-old-space-size=4096 client/index.js --generate --acctFile [accounts file] --datadir [data directory] --merkleMine [MerkleMine address] --recipient [recipient address] --caller [caller address]
+```
+
+This script will perform a number of validation checks in accordance with the specification, construct the Merkle proof for the given recipient and then submit
+a transaction from the given caller to the MerkleMine contract to generate a token allocation for the given recipient using the constructed Merkle proof.
+
+After you have generated your token, use the [Livepeer Protocol Explorer](https://explorer.livepeer.org/) to participate in the Livepeer network and delegate towards a transcoder.
+
+### Constructing a Merkle proof for a recipient
+
+```
+# By default this command will use the Ethereum main network
+# Use the --rinkeby flag to use the Rinkeby Ethereum test network
+# Use the --dev flag to use a custom development network with an Ethereum client (ganache-cli, Geth, Parity) running with JSON-RPC endpoints at http://localhost:8545
+node --max-old-space-size=4096 client/index.js --acctFile [accounts file] --merkleMine [MerkleMine address] --recipient [recipient address]
+```
+
+The script will perform a number of validation checks in accordance with the specification and then output the Merkle proof for the given recipient.
+
+### Constructing a Merkle root
+
+```
+node --max-old-space-size=4096 client/makeRoot.js --acctFile [accounts file]
+```
+
+The script will output the Merkle root of the constructed Merkle tree and the number of leaves (recipient accounts included).
+
+## Developing with the MerkleMine Contract
+
+### Testing
+
+```
 npm run test
 ```
 
-## Running the client
-
-```
-git clone https://github.com/livepeer/merkle-mine.git
-cd merkle-mine
-npm install
-
-# By default this command will use the mainnet network
-# Use the --rinkeby flag to use the Rinkeby network
-# Use the --dev flag to use a custom development network with an Ethereum client running on localhost
-node client/index.js --acctFile [accounts file] --datadir [data directory] --merkleMine [MerkleMine address] --recipient [recipient address] --caller [caller address]
-```
-
-## Working with a local dev chain
+### Deploying
 
 ```
 # Generate `genesisRoot` and `totalGenesisRecipients`
@@ -36,5 +80,16 @@ npm run client/makeRoot.js --acctFile [accounts file]
 
 # Configure `genesisRoot` and `totalGenesisRecipients` in `migrations/migrations.config.js`
 
-npm run migrate -- --network=dev
+# <network-name> can take on the following values
+# - `dev`: Use a custom development network with an Ethereum client (ganache-cli, Geth, Parity) running with JSON-RPC endpoints at http://localhost:8545
+# - `rinkeby`: Use the Rinkeby Ethereum test network (supported by Infura)
+# - `mainnet`: Use the Ethereum main network (supported by Infura)
+
+# Set the environment variable DATA_DIR=<data-directory>
+# <data-directory> is the directory in which your local keystore files live
+# If using `rinkeby`, set the environment variable RINKEBY_ACCOUNT=<deployment-account>
+# If using `mainnet`, set the environment variable MAINNET_ACCOUNT=<deployment-account>
+# <deployment-account> is the account you would like to submit the deployment transactions with
+# If using `dev`, the local Ethereum client will manage the deployment account
+npm run migrate -- --network=<network-name>
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Flags
 - `--caller`: address of account used to submit the MerkleMine contract transaction. Required if `--generate` flag is enabled
 - `--merkleMine`: address of MerkleMine contract
 - `--recipient`: address of account that is included in the MerkleMine genesis state that is the recipient of a token allocation
+- `--gasPrice`: gas price to use for submission of MerkleMine contract transaction. Default: 5 GWEI
 
 ### Generating a token allocation
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ npm install
 # Use the --dev flag to use a custom development network with an Ethereum client running on localhost
 node client/index.js --acctFile [accounts file] --datadir [data directory] --merkleMine [MerkleMine address] --recipient [recipient address] --caller [caller address]
 ```
+
+## Working with a local dev chain
+
+```
+# Generate `genesisRoot` and `totalGenesisRecipients`
+npm run client/makeRoot.js --acctFile [accounts file]
+
+# Configure `genesisRoot` and `totalGenesisRecipients` in `migrations/migrations.config.js`
+
+npm run migrate -- --network=dev
+```

--- a/client/index.js
+++ b/client/index.js
@@ -33,7 +33,7 @@ const main = async () => {
     try {
         await gen.performChecks()
     } catch (err) {
-        console.log("Some checks failed - see below for more details. Please visit livepeer.org to learn how to start participating in the Livepeer network and earning tokens.\n")
+        console.log("Some checks failed - see below for more details. Please visit livepeer.org to learn how to start participating in the Livepeer network.\n")
         console.error(err)
         return
     }

--- a/client/lib/MerkleMineGenerator.js
+++ b/client/lib/MerkleMineGenerator.js
@@ -1,19 +1,16 @@
 const Web3 = require("web3")
 const BigNumber = require("bignumber.js")
-const ethUtil = require("ethereumjs-util")
+const { addHexPrefix } = require("ethereumjs-util")
 const MerkleMineArtifact = require("./artifacts/MerkleMine.json")
 const ERC20Artifact = require("./artifacts/ERC20.json")
 
 module.exports = class MerkleMineGenerator {
-    constructor(provider, txKeyManager, merkleTree, merkleMineAddress, recipientAddress, callerAddress, gasPrice) {
+    constructor(provider, merkleTree, merkleMineAddress, recipientAddress) {
         this.web3 = new Web3()
         this.web3.setProvider(provider)
-        this.txKeyManager = txKeyManager
         this.merkleTree = merkleTree
-        this.merkleMineAddress = merkleMineAddress
-        this.recipientAddress = recipientAddress
-        this.callerAddress = callerAddress
-        this.gasPrice = gasPrice
+        this.merkleMineAddress = addHexPrefix(merkleMineAddress)
+        this.recipientAddress = addHexPrefix(recipientAddress)
     }
 
     async performChecks() {
@@ -23,7 +20,7 @@ module.exports = class MerkleMineGenerator {
         const numCandidateAccounts = this.merkleTree.getNumLeaves()
         const totalGenesisRecipients = await merkleMine.methods.totalGenesisRecipients().call()
 
-        if (numCandidateAccounts == totalGenesisRecipients) {
+        if (numCandidateAccounts != parseInt(totalGenesisRecipients)) {
             throw new Error(`Number of candidate accounts ${numCandidateAccounts} != totalGenesisRecipients ${totalGenesisRecipients}`)
         }
 
@@ -38,7 +35,15 @@ module.exports = class MerkleMineGenerator {
         console.log(`Validated locally generated Merkle root ${localRoot} with Merkle root stored in MerkleMine contract!`)
 
         // Validate proof locally
-        const validProof = this.merkleTree.verifyProof(this.recipientAddress, this.merkleTree.getProof(this.recipientAddress))
+        let proof
+
+        try {
+            proof = this.merkleTree.getProof(this.recipientAddress)
+        } catch (err) {
+            throw new Error(`The recipient address ${this.recipientAddress} was not included in the genesis state.`)
+        }
+
+        const validProof = this.merkleTree.verifyProof(this.recipientAddress, proof)
 
         if (!validProof) {
             throw new Error(`Local verification of Merkle proof failed!`)
@@ -68,19 +73,23 @@ module.exports = class MerkleMineGenerator {
         if (generated) {
             throw new Error(`Allocation for ${this.recipientAddress} already generated!`)
         }
+
+        console.log(`Merkle proof for recipient ${this.recipientAddress}: \n\n`)
+        console.log(this.merkleTree.getHexProof(this.recipientAddress))
+        console.log("\n\n")
     }
 
-    async submitProof() {
+    async submitProof(txKeyManager, callerAddress, gasPrice) {
         const merkleMine = await this.getMerkleMine()
-        const generateFn = merkleMine.methods.generate(this.recipientAddress, this.merkleTree.getHexProof(ethUtil.addHexPrefix(this.recipientAddress)))
-        const gas = await generateFn.estimateGas({from: this.callerAddress})
+        const generateFn = merkleMine.methods.generate(this.recipientAddress, this.merkleTree.getHexProof(his.recipientAddress))
+        const gas = await generateFn.estimateGas({from: callerAddress})
         const data = generateFn.encodeABI()
-        const nonce = await this.web3.eth.getTransactionCount(this.callerAddress, "pending")
+        const nonce = await this.web3.eth.getTransactionCount(callerAddress, "pending")
         const networkId = await this.web3.eth.net.getId()
 
-        const signedTx = this.txKeyManager.signTransaction({
+        const signedTx = txKeyManager.signTransaction({
             nonce: nonce,
-            gasPrice: this.gasPrice,
+            gasPrice: gasPrice,
             gasLimit: gas,
             to: this.merkleMineAddress,
             value: 0,
@@ -89,14 +98,12 @@ module.exports = class MerkleMineGenerator {
         })
 
         const receipt = await this.web3.eth.sendSignedTransaction(signedTx).on("transactionHash", txHash => {
-            console.log(`Submitted tx ${txHash} to generate allocation for ${this.recipientAddress} from ${this.callerAddress}`)
+            console.log(`Submitted tx ${txHash} to generate allocation for ${this.recipientAddress} from ${callerAddress}`)
         })
 
         if (receipt.status === "0x0") {
-            throw new Error(`Failed to generate allocation for ${this.recipientAddress} from ${this.callerAddress} in tx ${receipt.transactionHash}`)
+            throw new Error(`Failed to generate allocation for ${this.recipientAddress} from ${callerAddress} in tx ${receipt.transactionHash}`)
         }
-
-        console.log(`Generated allocation for ${this.recipientAddress}`)
     }
 
     async getMerkleMine() {

--- a/client/lib/MerkleMineGenerator.js
+++ b/client/lib/MerkleMineGenerator.js
@@ -81,7 +81,7 @@ module.exports = class MerkleMineGenerator {
 
     async submitProof(txKeyManager, callerAddress, gasPrice) {
         const merkleMine = await this.getMerkleMine()
-        const generateFn = merkleMine.methods.generate(this.recipientAddress, this.merkleTree.getHexProof(his.recipientAddress))
+        const generateFn = merkleMine.methods.generate(this.recipientAddress, this.merkleTree.getHexProof(this.recipientAddress))
         const gas = await generateFn.estimateGas({from: callerAddress})
         const data = generateFn.encodeABI()
         const nonce = await this.web3.eth.getTransactionCount(callerAddress, "pending")

--- a/client/makeRoot.js
+++ b/client/makeRoot.js
@@ -8,7 +8,7 @@ const argv = require("yargs")
 const main = async () => {
     console.log(`Creating Merkle tree with accounts in file: ${argv.acctFile}`)
     const merkleTree = await makeTree(argv.acctFile)
-    console.log(`Created Merkle tree with root ${merkleTree.getHexRoot()}`)
+    console.log(`Created Merkle tree with root ${merkleTree.getHexRoot()} and ${merkleTree.getNumLeaves()} leaves`)
 }
 
 try {

--- a/migrations/3_deploy_contracts.js
+++ b/migrations/3_deploy_contracts.js
@@ -1,18 +1,64 @@
 const config = require("./migrations.config.js")
+
 const MerkleMine = artifacts.require("MerkleMine")
+const TestToken = artifacts.require("TestToken")
+
+const deploy = async (deployer, artifact, ...args) => {
+    await deployer.deploy(artifact, ...args)
+    return await artifact.deployed()
+}
+
+const getCurrentBlock = async () => {
+    return new Promise((resolve, reject) => {
+        return web3.eth.getBlockNumber((err, blkNum) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(blkNum)
+            }
+        })
+    })
+}
 
 module.exports = function(deployer, network) {
-    if (network === "rinkeby" || network === "mainnet") {
-        deployer.deploy(
-            MerkleMine,
-            config.token,
-            config.genesisRoot,
-            config.totalGenesisTokens,
-            config.totalGenesisRecipients,
-            config.balanceThreshold,
-            config.genesisBlock,
-            config.callerAllocationStartBlock,
-            config.callerAllocationEndBlock
-        )
-    }
+    deployer.then(async () => {
+        const currentBlock = await getCurrentBlock()
+
+        if (network === "rinkeby" || network === "mainnet") {
+            await deploy(
+                deployer,
+                MerkleMine,
+                config.token,
+                config.genesisRoot,
+                config.totalGenesisTokens,
+                config.totalGenesisRecipients,
+                config.balanceThreshold,
+                config.genesisBlock,
+                currentBlock + config.blocksToCliff,
+                currentBlock + config.blocksToCliff + config.callerAllocationPeriod
+            )
+        } else {
+            deployer.logger.log("On dev network - creating test ERC20 token")
+
+            const token = await deploy(deployer, TestToken)
+            const merkleMine = await deploy(
+                deployer,
+                MerkleMine,
+                token.address, // Use custom test ERC20 token on dev chain
+                config.genesisRoot,
+                config.totalGenesisTokens,
+                config.totalGenesisRecipients,
+                config.balanceThreshold,
+                0, // Set default genesis block on a dev chain to block 0
+                currentBlock + config.blocksToCliff,
+                currentBlock + config.blocksToCliff + config.callerAllocationPeriod
+            )
+
+            await token.mint(merkleMine.address, config.totalGenesisTokens)
+            deployer.logger.log(`Minted ${config.totalGenesisTokens} to MerkleMine`)
+
+            await merkleMine.start()
+            deployer.logger.log(`Started MerkleMine`)
+        }
+    })
 }

--- a/migrations/migrations.config.js
+++ b/migrations/migrations.config.js
@@ -1,10 +1,10 @@
 module.exports = {
     token: "0x3cfdae2d5d52a98bc0e28ce5bbefd1b1aa441613",
     genesisRoot: "0xcfc715d2f123d7d20bb9991b3810b80f7d796f53aa70bf5da6e1fa9b4d2d1695",
-    totalGenesisTokens: 6000000 * (10**18),
     totalGenesisRecipients: 95447,
+    totalGenesisTokens: 6000000 * (10**18),
     balanceThreshold: 100,
-    genesisBlock: 2064302,
-    callerAllocationStartBlock: 2088350,
-    callerAllocationEndBlock: 2089150
+    genesisBlock: 0,
+    blocksToCliff: 100,
+    callerAllocationPeriod: 200
 }

--- a/truffle.js
+++ b/truffle.js
@@ -23,6 +23,11 @@ const createProvider = memoizeProviderCreator()
 
 module.exports = {
   networks: {
+    dev: {
+      host: "localhost",
+      port: 8545,
+      network_id: "*"
+    },
     rinkeby: {
       provider: () => {
         return createProvider(process.env.RINKEBY_ACCOUNT, process.env.DATA_DIR, "https://rinkeby.infura.io", process.env.READ_ONLY)


### PR DESCRIPTION
- The default behavior for the client script is to always print the proof for a given recipient. The MerkleMine generation tx will only be submitted if the `--generate` flag is passed. Closes #7 
- Add additional console output after successfully generating a token allocation and in the scenario where a provided recipient is not included in the genesis state. Closes #6 
- Updated README with additional documentation for running the client scripts. Closes #5 
- Automate deployment of a test ERC20 token when running with a local dev chain such as ganache-cli